### PR TITLE
refactor: main.go 파일 구조 분리

### DIFF
--- a/app/loader.go
+++ b/app/loader.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/spf13/viper"
+	"os"
+)
+
+func loadConfig() bool {
+	_, err := os.Stat(file)
+	if err != nil {
+		return false
+	}
+
+	viper.SetConfigFile(file)
+	viper.SetConfigType("toml")
+
+	err = viper.ReadInConfig()
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	fmt.Println(conf.DBHost)
+	err = viper.GetViper().Unmarshal(&conf)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	return true
+}
+
+func parseConfig() bool {
+	flag.StringVar(&file, "c", "config.toml", "config file")
+	flag.Parse()
+	if !loadConfig() {
+		return false
+	}
+
+	return true
+}

--- a/app/main.go
+++ b/app/main.go
@@ -1,8 +1,31 @@
 package main
 
-import "fmt"
+import (
+	"github.com/HongJungWan/ffmpeg-video-modules/app/helper"
+	"github.com/HongJungWan/ffmpeg-video-modules/app/infrastructure/configs"
+	"github.com/HongJungWan/ffmpeg-video-modules/app/infrastructure/logger"
+	"go.uber.org/zap"
+	"os"
+)
 
-// FIXME: 메인 실행 파일
+var (
+	conf = configs.Config{}
+	file string
+)
+
 func main() {
-	fmt.Println("main.go 동작 테스트")
+	if !parseConfig() {
+		helper.ShowHelp()
+		os.Exit(-1)
+	}
+
+	log := logger.ConfigureLogger(conf.Environment)
+	logger.LogCurrentLevel(log)
+
+	db := configs.ConnectionDB(&conf)
+	log.Info("config", zap.Any("config", db))
+
+	logger.LogCurrentConfig(conf)
+
+	startServer()
 }

--- a/app/server.go
+++ b/app/server.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/HongJungWan/ffmpeg-video-modules/app/helper"
+	"github.com/HongJungWan/ffmpeg-video-modules/app/infrastructure/router"
+	"net/http"
+)
+
+func startServer() {
+	routers := router.NewRouter(conf)
+
+	server := &http.Server{
+		Addr:    ":3031",
+		Handler: routers,
+	}
+	err := server.ListenAndServe()
+	if err != nil {
+		helper.ErrorPanic(err)
+	}
+}


### PR DESCRIPTION
- `main.go` 파일의 코드를 `loader.go`와 `server.go`로 분리하여 관리